### PR TITLE
Fix dependency for install from pypi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,6 @@ setup(name='jedhy',
           'jedhy': ['*.hy', '__pycache__/*'],
       },
 
-      # install_requires=[],
+      install_requires=["toolz"],
       # include_package_data=True,
       )


### PR DESCRIPTION
Here is a fix for the installation process.

Would it be possible to upload jedhy to pypi @ekaschalk ? So that I can easily install it with pip install hy?

https://packaging.python.org/tutorials/packaging-projects/