### PR TITLE
Workaround for hy 1.0a3

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,6 +1,6 @@
 * Jedhy
 
-/Last Hy version verified working for: Hy 0.16.0/
+/Last Hy version verified working for: Hy 1.0a1/
 
 ~jedhy~ provides autocompletion, documentation introspection and formatting, and
 other tools useful to IDEs for [[https://github.com/hylang/hy][Hy]], a lisp embedded in Python.

--- a/README.org
+++ b/README.org
@@ -1,6 +1,8 @@
 * Jedhy
 
-/Last Hy version verified working for: Hy 1.0a1/
+/Only Hy version verified working for: Hy 1.0a3/
+you also need to change hy-jedhy.el in hymode.
+checkout https://github.com/jinhan23/hy-mode
 
 ~jedhy~ provides autocompletion, documentation introspection and formatting, and
 other tools useful to IDEs for [[https://github.com/hylang/hy][Hy]], a lisp embedded in Python.

--- a/jedhy/api.hy
+++ b/jedhy/api.hy
@@ -13,18 +13,18 @@
 ;; * API
 
 (defclass API [object]
-  (defn --init-- [self &optional globals- locals- macros-]
+  (defn __init__ [self [globals- None] [locals- None] [macros- None]]
     (self.set-namespace globals- locals- macros-)
 
     (setv self.-cached-prefix None))
 
-  (defn set-namespace [self &optional globals- locals- macros-]
+  (defn set-namespace [self [globals- None] [locals- None] [macros- None]]
     "Rebuild namespace for possibly given `globals-`, `locals-`, and `macros-`.
 
 Typically, the values passed are:
   globals- -> (globals)
   locals-  -> (locals)
-  macros-  -> --macros--"
+  macros-  -> __macros__"
     (setv self.namespace (Namespace globals- locals- macros-)))
 
   (defn complete [self prefix-str]

--- a/jedhy/inspection.hy
+++ b/jedhy/inspection.hy
@@ -11,11 +11,11 @@
 ;; * Parameters
 
 (defclass Parameter [object]
-  (defn --init-- [self symbol &optional default]
+  (defn __init__ [self symbol [default None]]
     (setv self.symbol (unmangle symbol))
     (setv self.default default))
 
-  (defn --str-- [self]
+  (defn __str__ [self]
     (if (none? self.default)
         self.symbol
         (.format "[{} {}]" self.symbol self.default))))
@@ -23,7 +23,7 @@
 ;; * Signature
 
 (defclass Signature [object]
-  (defn --init-- [self func]
+  (defn __init__ [self func]
     (try (setv argspec (inspect.getfullargspec func))
          (except [e TypeError]
            (raise (TypeError "Unsupported callable for hy Signature."))))
@@ -39,7 +39,7 @@
            argspec)))
 
   #@(staticmethod
-      (defn -parametrize [symbols &optional defaults]
+      (defn -parametrize [symbols [defaults None]]
         "Construct many Parameter for `symbols` with possibly defaults."
         (when symbols
           (tuple (map Parameter
@@ -122,7 +122,7 @@
          [self.varkw    "#**"]
          [self.kwargs   "&kwonly"]]))
 
-  (defn --str-- [self]
+  (defn __str__ [self]
     (reduce self.-acc-lispy-repr self.-arg-opener-pairs (str))))
 
 ;; * Docstring conversion
@@ -206,24 +206,24 @@
 ;; ** Internal
 
 (defclass Inspect [object]
-  (defn --init-- [self obj]
+  (defn __init__ [self obj]
     (setv self.obj obj))
 
   #@(property
       (defn -docs-first-line [self]
-        (or (and self.obj.--doc--
-                 (-> self.obj.--doc-- (.splitlines) first))
+        (or (and self.obj.__doc__
+                 (-> self.obj.__doc__ (.splitlines) first))
             "")))
 
   #@(property
       (defn -docs-rest-lines [self]
-        (or (and self.obj.--doc--
-                 (->> self.obj.--doc-- (.splitlines) rest (.join "\n")))
+        (or (and self.obj.__doc__
+                 (->> self.obj.__doc__ (.splitlines) rest (.join "\n")))
             "")))
 
   #@(property
       (defn -args-docs-delim [self]
-        (or (and self.obj.--doc--
+        (or (and self.obj.__doc__
                  " - ")
             "")))
 
@@ -250,7 +250,7 @@
 
   #@(property
       (defn obj-name [self]
-        (unmangle self.obj.--name--)))
+        (unmangle self.obj.__name__)))
 
   #@(property
       (defn lambda? [self]
@@ -265,7 +265,7 @@
   #@(property
       (defn method-wrapper? [self]
         "Is object of type 'method-wrapper'?"
-        (instance? (type print.--str--) self.obj)))
+        (isinstance self.obj (type print.__str__))))
 
   #@(property
       (defn compile-table? [self]

--- a/jedhy/macros.hy
+++ b/jedhy/macros.hy
@@ -5,6 +5,7 @@
 (require [hy.extra.anaphoric [*]])
 
 (import functools
+        itertools
         [toolz.curried :as tz]
 
         [hy.lex [unmangle
@@ -18,32 +19,57 @@
 
 ;; * Tag Macros
 
-(deftag t [form]
+(defmacro "#t" [form]
   "Cast evaluated form to a tuple. Useful via eg. #t(-> x f1 f2 ...)."
   `(tuple ~form))
 
-(deftag $ [form]
+(defmacro "#$" [form]
   "Partially apply a form eg. (#$(map inc) [1 2 3])."
   `(functools.partial ~@form))
 
-(deftag f [form]
+(defmacro "#f" [form]
   "Flipped #$."
   `(tz.flip ~@form))
 
 ;; * Misc
 
-(defn -allkeys [d &kwonly [parents (,)]]
+(defn -allkeys [d * [parents (,)]]
   "In-order tuples of keys of nested, variable-length dict."
   (if (isinstance d (, list tuple))
       []
       #t(->> d
          (tz.keymap (fn [k] (+ parents (, k))))
          dict.items
-         (*map (fn [k v]
-                 (if (isinstance v dict)
-                     (-allkeys v :parents k)
-                     [k])))
+         (itertools.starmap
+           (fn [k v]
+             (if (isinstance v dict)
+               (-allkeys v :parents k)
+               [k])))
          tz.concat)))
+
+(defn drop [count coll]
+  "Drop `count` elements from `coll` and yield back the rest."
+  (islice coll count None))
+
+(defn first [coll]
+  "Return first item from `coll`."
+  (next (iter coll) None))
+
+(defn last [coll]
+  "Return last item from `coll`."
+  (get (tuple coll) -1))
 
 (defn allkeys [d]
   (->> d -allkeys (map last) tuple))
+
+(defn juxt [f #* fs]
+  "Return a function applying each `fs` to args, collecting results in a list."
+  (setv fs (+ (, f) fs))
+  (fn [#* args #** kwargs]
+    (lfor f fs (f #* args #** kwargs))))
+
+(setv chain itertools.chain
+      islice itertools.islice
+      reduce functools.reduce
+      remove itertools.filterfalse
+      repeat itertools.repeat)

--- a/jedhy/macros.hy
+++ b/jedhy/macros.hy
@@ -11,6 +11,20 @@
         [hy.lex [unmangle
                  mangle :as unfixed-mangle]])
 
+
+;; * 1.0a3 workaround
+(defn second [form]
+  (get form 1))
+
+(defn first [form]
+  (if form (get form 0)))
+
+(defn none? [form]
+  (is form None))
+
+(defn string? [form]
+  (isinstance form str))
+
 ;; * Hy Overwrites
 
 ;; We have different requirements in the empty string case

--- a/jedhy/models.hy
+++ b/jedhy/models.hy
@@ -9,9 +9,9 @@
         hy
         hy.compiler
         hy.macros
-        [hy.compiler [-special-form-compilers :as -compile-table]]
+        [hy.compiler [_special_form_compilers :as -compile-table]]
 
-        ;; Below imports populate --macros-- for Namespace
+        ;; Below imports populate __macros__ for Namespace
         [hy.core.language [*]]
         [hy.core.macros [*]])
 
@@ -26,11 +26,11 @@
 ;; * Namespace
 
 (defclass Namespace [object]
-  (defn --init-- [self &optional globals- locals- macros-]
+  (defn __init__ [self [globals- None] [locals- None] [macros- None]]
     ;; Components
     (setv self.globals       (or globals- (globals)))
     (setv self.locals        (or locals- (locals)))
-    (setv self.macros        (tz.keymap unmangle (or macros- --macros--)))
+    (setv self.macros        (tz.keymap unmangle (or macros- __macros__)))
     (setv self.compile-table (self.-collect-compile-table))
     (setv self.shadows       (self.-collect-shadows))
 
@@ -40,9 +40,9 @@
   #@(staticmethod
       (defn -to-names [key]
         "Function for converting keys (strs, functions, modules...) to names."
-        (unmangle (if (instance? str key)
+        (unmangle (if (string? key)
                       key
-                      key.--name--))))
+                      key.__name__))))
 
   (defn -collect-compile-table [self]
     "Collect compile table as dict."
@@ -83,22 +83,22 @@
 ;; * Candidate
 
 (defclass Candidate [object]
-  (defn --init-- [self symbol &optional namespace]
+  (defn __init__ [self symbol [namespace None]]
     (setv self.symbol    (unmangle symbol))
     (setv self.mangled   (mangle symbol))
     (setv self.namespace (or namespace (Namespace))))
 
-  (defn --str-- [self]
+  (defn __str__ [self]
     self.symbol)
 
-  (defn --repr-- [self]
+  (defn __repr__ [self]
     (.format "Candidate<(symbol={}>)" self.symbol))
 
-  (defn --eq-- [self other]
-    (when (instance? Candidate other)
+  (defn __eq__ [self other]
+    (when (isinstance other Candidate)
       (= self.symbol other.symbol)))
 
-  (defn --bool-- [self]
+  (defn __bool__ [self]
     (bool self.symbol))
 
   (defn compiler? [self]
@@ -158,7 +158,7 @@
                             "shadowed"]
 
                            [obj?
-                            (self.-translate-class obj.--class--.--name--)]
+                            (self.-translate-class obj.__class__.__name__)]
 
                            [(.compiler? self)
                             "compiler"]
@@ -173,7 +173,7 @@
 (defclass Prefix [object]
   "A completion candidate."
 
-  (defn --init-- [self prefix &optional namespace]
+  (defn __init__ [self prefix [namespace None]]
     (setv self.prefix prefix)
     (setv self.namespace (or namespace (Namespace)))
 
@@ -182,7 +182,7 @@
 
     (setv self.completions (tuple)))
 
-  (defn --repr-- [self]
+  (defn __repr__ [self]
     (.format "Prefix<(prefix={})>" self.prefix))
 
   #@(staticmethod
@@ -217,9 +217,9 @@
         (+ (str self.candidate) "." completion)
         completion))
 
-  (defn complete [self &optional cached-prefix]
+  (defn complete [self [cached-prefix None]]
     "Get candidates for a given Prefix."
-    ;; Short circuit the case: "1+nonsense.real-attr" eg. "foo.--prin"
+    ;; Short circuit the case: "1+nonsense.real-attr" eg. "foo.__prin"
     (when (and self.has-attr?  ; The and ordering here matters for speed
                (not self.obj?))
       (setv self.completions (tuple))

--- a/jedhy/models.hy
+++ b/jedhy/models.hy
@@ -9,7 +9,7 @@
         hy
         hy.compiler
         hy.macros
-        [hy.compiler [_special_form_compilers :as -compile-table]]
+        ;; [hy.compiler [_special_form_compilers :as -compile-table]]
 
         ;; Below imports populate __macros__ for Namespace
         [hy.core.language [*]]
@@ -31,7 +31,7 @@
     (setv self.globals       (or globals- (globals)))
     (setv self.locals        (or locals- (locals)))
     (setv self.macros        (tz.keymap unmangle (or macros- __macros__)))
-    (setv self.compile-table (self.-collect-compile-table))
+    ;; (setv self.compile-table (self.-collect-compile-table))
     (setv self.shadows       (self.-collect-shadows))
 
     ;; Collected
@@ -62,7 +62,8 @@
       (chain (allkeys self.globals)
              (allkeys self.locals)
              (.keys self.macros)
-             (.keys self.compile-table))
+            ;;  (.keys self.compile-table)
+             )
       (map self.-to-names)
       distinct
       tuple))
@@ -101,10 +102,10 @@
   (defn __bool__ [self]
     (bool self.symbol))
 
-  (defn compiler? [self]
-    "Is candidate a compile table construct and return it."
-    (try (get self.namespace.compile-table self.symbol)
-         (except [e KeyError] None)))
+  ;; (defn compiler? [self]
+  ;;   "Is candidate a compile table construct and return it."
+  ;;   (try (get self.namespace.compile-table self.symbol)
+  ;;        (except [e KeyError] None)))
 
   (defn macro? [self]
     "Is candidate a macro and return it."
@@ -127,7 +128,8 @@
     ;; both shadowed and in the compile table as shadowed (eg. `+`)
     (or (self.macro?)
         (self.evaled?)
-        (self.compiler?)))
+        ;; (self.compiler?)
+        ))
 
   (defn attributes [self]
     "Return attributes for obj if they exist."
@@ -151,7 +153,7 @@
   (defn annotate [self]
     "Return annotation for a candidate."
     (setv obj (self.evaled?))
-    (setv obj? (not (none? obj)))  ; Obj could be instance of bool
+    (setv obj? (not (is obj None)))  ; Obj could be instance of bool
 
     ;; Shadowed takes first priority but compile table takes last priority
     (setv annotation (cond [(self.shadow?)
@@ -160,8 +162,8 @@
                            [obj?
                             (self.-translate-class obj.__class__.__name__)]
 
-                           [(.compiler? self)
-                            "compiler"]
+                          ;;  [(.compiler? self)
+                          ;;   "compiler"]
 
                            [(.macro? self)
                             "macro"]))


### PR DESCRIPTION
# Overview
For someone who wants to use the most recent hy with jedhy and hy-mode in emacs.
Thanks to the work done by @rinx, I made workaround version of jedhy and hy-mode for hy 1.0a3.

# How to apply
You need to update both jedhy and hy-mode to make them work.
## jedhy
(In workaround_for_hy-1.0a3 branch in http://github.com/jethack23/jedhy)
Clone my commit of jedhy and install jedhy with this clone. I used this command at the directory of repository.
```shell
pip install .
```
## hy-mode
Clone my commit of hy-mode and apply change I made to your hy-jedhy.el.
(In workaround_for_hy-1.0a3 branch in http://github.com/jethack23/hy-mode)
In my case, it was in
```shell
~/.emacs.d/elpa/hy-mode-{version}/hy-jedhy.el
```
You may need to X-x byte-compile-file to replace hy-jedhy.elc